### PR TITLE
Arduinozyme.ino: Fixes pinMode for digital output, Adds analog/PWM output as 'O'

### DIFF
--- a/Arduinozyme/Arduinozyme.ino
+++ b/Arduinozyme/Arduinozyme.ino
@@ -57,7 +57,27 @@ void txtEval (char *buf) {
       x = digitalRead(d);
       break;
     case 'o':
+      pinMode(d,OUTPUT);
       digitalWrite(d, x%2);
+      break;
+    case 'O': // write analog
+      pinMode(d,OUTPUT);
+      analogWrite(d,x);
+      break;
+// Teensy 3.1 and 3.0 specifc code
+#if defined(__MK20DX256__)|| defined(__MK20DX128__)
+    case 'F':  // See https://www.pjrc.com/teensy/td_pulse.html
+      analogWriteFrequency(d,x);  
+      break;
+    case 'R':  // Teensy3 bits of resolution 2-16 default was 8
+      analogWriteResolution(x);
+      break;  
+#endif
+    case 't':
+      tone(d,x);
+      break;
+    case 'T':
+      noTone(d);
       break;
     case 'm':
       delay(x);


### PR DESCRIPTION
This fix makes several changes to the Arduinozyme sketch.  The Arduinozyme sketch is useful for Teensy3.0 and Teensy3.1.

The code didn't set the pinMode from INPUT, so the 'o' command fails.  Setting the pinMode() before digitalWrite(pin,x%2) solves this.

Teensy boards are capable of Analog/PWM output.  See https://www.pjrc.com/teensy/td_pulse.html for details.

Analog output is added with a 'O' command.

Teensyduino's 'tone(pin,frequency)' command was added as '[pin]d[freq]T'  with freq==0, it turns off with a noTone(pin).  Works fine with a LED:  10d 2T  2000m 30T 2000m 0T.   

Teensy3.0 and Teensy 3.1 have analogWriteFrequency(pin,frequency) and analogWriteResolution(bits 2-16) extensions that are implemented as command 'F' and 'R'.  This is pretty cool.

Arduinozyme is missing the 'h', 'v' and 't' commands of txtzyme.
