### PR TITLE
Arduinozyme.ino: change T command to tone(pin,freq) with freq=0 meaning stop.

### DIFF
--- a/Arduinozyme/Arduinozyme.ino
+++ b/Arduinozyme/Arduinozyme.ino
@@ -56,6 +56,7 @@ void txtEval (char *buf) {
       break;
     case 'i':
       pinMode(d,INPUT);
+    case 'r':
       x = digitalRead(d);
       break;
     case 'o':


### PR DESCRIPTION
 Arduinozyme.ino: change T command to tone(pin,freq) with freq=0 calling noTone() to vacate 't' command.

I noticed that the Txtzyme code has a few commands the Arduinozyme does not: 't', 'h', 'v'.   This patch removes the clash with 't', by using '0T' to turn off the tone(pin,frequency) command with noTone(pin). 

Limits on frequencies are 1-65535 Hz.   If you try higher, the frequency (freq mod 65536) with no-operation behavior at the zeros.  If you try 0T, it stops oscillating and may be left in the 0 or 1 state.   Try '0o 1T 1200m 0T ip'  
