### PR TITLE
Reduce bufsize to fit Arduino uno

### DIFF
--- a/Arduinozyme/Arduinozyme.ino
+++ b/Arduinozyme/Arduinozyme.ino
@@ -1,7 +1,7 @@
 
 unsigned int x = 0;
 int d = 13;
-const unsigned int bufsize = 2048;
+const unsigned int bufsize = 1650; // 2048 is too large for Arduino Uno
 
 void setup() {
   Serial.begin(9600);


### PR DESCRIPTION
With a 2048 byte command buffer, an Arduino Uno hangs.  Compilation for an Uno reports

```
Sketch uses 4454 bytes (13%) of program storage space. Maximum is 32256 bytes.
Global variables use 209 bytes (10%) of dynamic memory, leaving 1839 bytes for local variables. Maximum is 2048 bytes.
```
Therefore a local `buf[2048]` consumes the total dynamic memory for all  local variables.  The effect I see is that it hangs.  If you push bufsize down to 90% of the unallocated 1839 bytes of dynamic storage, or 1650 bytes, that leaves 189 bytes for other local variables.  This seems stable for a common Arduino Uno.